### PR TITLE
:bug: docs - hide nav when collapsed

### DIFF
--- a/docs/pdoc_template/html.mako
+++ b/docs/pdoc_template/html.mako
@@ -455,9 +455,11 @@
 
 <script>
   const sidebar = document.querySelector("body > main > div");
+  const sidebar_nav = document.querySelector("body > main > div > nav");
   const sidebar_content = document.getElementById("sidebar_content");
   document.getElementById("index_button_button").onclick = function () {
     sidebar.classList.toggle('sidebar_small');
+    sidebar_nav.classList.toggle('hide_content');
     sidebar_content.classList.toggle('hide_content');
   }
   </script>


### PR DESCRIPTION
This fixes a bug where the nav section does not get collapsed (when the collapse button is clicked).
This bug caused that URLs positioned left on the docs are not clickable (because they were overlapped by the uncollapsed nav).