### PR TITLE
[MRG] Remove deprecated closed argument in pd.daterange

### DIFF
--- a/tsflex/features/segmenter/strided_rolling.py
+++ b/tsflex/features/segmenter/strided_rolling.py
@@ -435,7 +435,6 @@ class TimeStridedRolling(StridedRolling):
             end=self.end - self.window + window_offset,
             freq=self.stride,
             name=series.index.name,
-            closed=None,
         )
 
     def _construct_start_end_times(self) -> Tuple[np.ndarray, np.ndarray]:


### PR DESCRIPTION
The `closed` argument was set to `None` which is the default, removing it should thus not have any impact.
Since Pandas 1.4.0 this argument has been deprecated in favour of the `inclusive` argument so you get a lot of warnings when running the code.
The default argument to `inclusive` is `"both"` which has the same behaviour as the current code. I thus see no need to add it.
https://pandas.pydata.org/docs/reference/api/pandas.date_range.html