### PR TITLE
:sparkles: support segment start and end idxs

### DIFF
--- a/tests/test_features_feature_collection.py
+++ b/tests/test_features_feature_collection.py
@@ -854,6 +854,93 @@ def test_featurecollection_reduce_multiple_feat_output(dummy_data):
     fc_reduce.calculate(dummy_data)
 
 
+def test_featurecollection_reduce_segment_start_idx(dummy_data):
+    fc = FeatureCollection(
+        MultipleFeatureDescriptors(
+            functions=[np.max, np.min, np.std, np.sum],
+            series_names="EDA",
+            windows=["5s", "30s", "1min"],
+        )
+    )
+    segment_start_idxs = dummy_data.index[::100][:10]
+    df_feat_tot = fc.calculate(data=dummy_data, segment_start_idxs=segment_start_idxs, return_df=True, show_progress=True)
+
+    for _ in range(5):
+        col_subset = random.sample(
+            list(df_feat_tot.columns), random.randint(1, len(df_feat_tot.columns))
+        )
+        fc_reduced = fc.reduce(col_subset)
+        fc_reduced.calculate(dummy_data, segment_start_idxs=segment_start_idxs)
+        for fd in flatten(fc._feature_desc_dict.values()):
+            assert fd.stride == None
+
+    # also test the reduce function on a single column
+    fc_reduced = fc.reduce(random.sample(list(df_feat_tot.columns), 1))
+    fc_reduced.calculate(dummy_data, segment_start_idxs=segment_start_idxs)
+
+    # should also work when fc is deleted
+    del fc
+    fc_reduced.calculate(dummy_data, segment_start_idxs=segment_start_idxs)
+
+
+def test_featurecollection_reduce_segment_end_idx(dummy_data):
+    fc = FeatureCollection(
+        MultipleFeatureDescriptors(
+            functions=[np.max, np.min, np.std, np.sum],
+            series_names="EDA",
+            windows=["5s", "30s", "1min"],
+        )
+    )
+    segment_end_idxs = dummy_data.index[::100][10:20]
+    df_feat_tot = fc.calculate(data=dummy_data, segment_end_idxs=segment_end_idxs, return_df=True, show_progress=True)
+
+    for _ in range(5):
+        col_subset = random.sample(
+            list(df_feat_tot.columns), random.randint(1, len(df_feat_tot.columns))
+        )
+        fc_reduced = fc.reduce(col_subset)
+        fc_reduced.calculate(dummy_data, segment_end_idxs=segment_end_idxs)
+        for fd in flatten(fc._feature_desc_dict.values()):
+            assert fd.stride == None
+
+    # also test the reduce function on a single column
+    fc_reduced = fc.reduce(random.sample(list(df_feat_tot.columns), 1))
+    fc_reduced.calculate(dummy_data, segment_end_idxs=segment_end_idxs)
+
+    # should also work when fc is deleted
+    del fc
+    fc_reduced.calculate(dummy_data, segment_end_idxs=segment_end_idxs)
+
+
+def test_featurecollection_reduce_segment_start_and_end_idx(dummy_data):
+    fc = FeatureCollection(
+        MultipleFeatureDescriptors(
+            functions=[np.max, np.min, np.std, np.sum],
+            series_names="EDA",
+        )
+    )
+    segment_start_idxs = dummy_data.index[::100][:10]    
+    segment_end_idxs = dummy_data.index[::100][10:20]
+    df_feat_tot = fc.calculate(data=dummy_data, segment_start_idxs=segment_start_idxs, segment_end_idxs=segment_end_idxs, return_df=True, show_progress=True)
+
+    for _ in range(5):
+        col_subset = random.sample(
+            list(df_feat_tot.columns), random.randint(1, len(df_feat_tot.columns))
+        )
+        fc_reduced = fc.reduce(col_subset)
+        fc_reduced.calculate(dummy_data, segment_start_idxs=segment_start_idxs, segment_end_idxs=segment_end_idxs)
+        for fd in flatten(fc._feature_desc_dict.values()):
+            assert fd.stride == None
+
+    # also test the reduce function on a single column
+    fc_reduced = fc.reduce(random.sample(list(df_feat_tot.columns), 1))
+    fc_reduced.calculate(dummy_data, segment_start_idxs=segment_start_idxs, segment_end_idxs=segment_end_idxs)
+
+    # should also work when fc is deleted
+    del fc
+    fc_reduced.calculate(dummy_data, segment_start_idxs=segment_start_idxs, segment_end_idxs=segment_end_idxs)
+
+
 def test_featurecollection_error_val(dummy_data):
     fd = FeatureDescriptor(
         function=np.max,

--- a/tests/test_features_feature_collection.py
+++ b/tests/test_features_feature_collection.py
@@ -398,7 +398,7 @@ def test_sequence_segment_start_and_end_idxs():
             FeatureDescriptor(len, "dummy"),
         ]
     )
-    res = fc.calculate(s, segment_start_idxs=segment_start_idxs, segment_end_idxs=segment_end_idxs, return_df=True, window_idx="begin")
+    res = fc.calculate(s, segment_start_idxs=segment_start_idxs, segment_end_idxs=segment_end_idxs, return_df=True, window_idx="begin", n_jobs=1)
     assert all(res.index == segment_start_idxs)
     assert np.all(res["dummy__amin__w=manual"] == segment_start_idxs)
     assert np.all(res["dummy__len__w=manual"] == [5]*3 + [2])
@@ -416,7 +416,7 @@ def test_time_segment_start_and_end_idxs():
             FeatureDescriptor(len, "dummy"),
         ]
     )
-    res = fc.calculate(s, segment_start_idxs=segment_start_idxs, segment_end_idxs=segment_end_idxs, return_df=True, window_idx="begin")
+    res = fc.calculate(s, segment_start_idxs=segment_start_idxs, segment_end_idxs=segment_end_idxs, return_df=True, window_idx="begin", n_jobs=1)
     assert all(res.index == segment_start_idxs)
     assert np.all(res["dummy__amin__w=manual"] == [0, 5, 3, 3])
     assert np.all(res["dummy__len__w=manual"] == [5]*3 + [2])

--- a/tests/test_features_feature_collection.py
+++ b/tests/test_features_feature_collection.py
@@ -363,10 +363,34 @@ def test_time_segment_end_idxs_not_sorted():
     assert all(res.index == segment_end_idxs)
 
 
+def test_time_segment_start_idxs_duplicate():
+    s = pd.Series(np.arange(20), name="dummy")
+    s.index = pd.date_range("2021-08-09", freq="1h", periods=20)
+    segment_start_idxs = s.index[[0, 3, 3, 5]]
+
+    fc = FeatureCollection(
+        FeatureDescriptor(np.min, "dummy", "1h")
+    )
+    res = fc.calculate(s, segment_start_idxs=segment_start_idxs, return_df=True, window_idx="begin")
+    assert all(res.index == segment_start_idxs)
+
+
+def test_time_segment_end_idxs_not_duplicate():
+    s = pd.Series(np.arange(20), name="dummy")
+    s.index = pd.date_range("2021-08-09", freq="1h", periods=20)
+    segment_end_idxs = s.index[[5, 8, 8, 10]]
+
+    fc = FeatureCollection(
+        FeatureDescriptor(np.min, "dummy", "1h")
+    )
+    res = fc.calculate(s, segment_end_idxs=segment_end_idxs, return_df=True, window_idx="end")
+    assert all(res.index == segment_end_idxs)
+
+
 def test_sequence_segment_start_and_end_idxs():
     s = pd.Series(np.arange(20), name="dummy")
-    segment_start_idxs = [0, 5, 3]
-    segment_end_idxs = [5, 10, 8]
+    segment_start_idxs = [0, 5, 3, 3]
+    segment_end_idxs = [5, 10, 8, 5]
 
     fc = FeatureCollection(
         [
@@ -377,14 +401,14 @@ def test_sequence_segment_start_and_end_idxs():
     res = fc.calculate(s, segment_start_idxs=segment_start_idxs, segment_end_idxs=segment_end_idxs, return_df=True, window_idx="begin")
     assert all(res.index == segment_start_idxs)
     assert np.all(res["dummy__amin__w=manual"] == segment_start_idxs)
-    assert np.all(res["dummy__len__w=manual"] == 5)
+    assert np.all(res["dummy__len__w=manual"] == [5]*3 + [2])
 
 
 def test_time_segment_start_and_end_idxs():
     s = pd.Series(np.arange(20), name="dummy")
     s.index = pd.date_range("2021-08-09", freq="1h", periods=20)
-    segment_start_idxs = s.index[[0, 5, 3]]
-    segment_end_idxs = s.index[[5, 10, 8]]
+    segment_start_idxs = s.index[[0, 5, 3, 3]]
+    segment_end_idxs = s.index[[5, 10, 8, 5]]
 
     fc = FeatureCollection(
         [
@@ -394,16 +418,13 @@ def test_time_segment_start_and_end_idxs():
     )
     res = fc.calculate(s, segment_start_idxs=segment_start_idxs, segment_end_idxs=segment_end_idxs, return_df=True, window_idx="begin")
     assert all(res.index == segment_start_idxs)
-    assert np.all(res["dummy__amin__w=manual"] == [0, 5, 3])
-    assert np.all(res["dummy__len__w=manual"] == 5)
+    assert np.all(res["dummy__amin__w=manual"] == [0, 5, 3, 3])
+    assert np.all(res["dummy__len__w=manual"] == [5]*3 + [2])
 
 
 # TODO: 
 # - test index
-# - test end & start idxs
 # - test error when passing stride
-# CODING: window optioneel maken
-
 
 def test_uneven_sampled_series_feature_collection(dummy_data):
     fd = FeatureDescriptor(

--- a/tests/test_features_feature_collection.py
+++ b/tests/test_features_feature_collection.py
@@ -37,6 +37,7 @@ def test_single_series_feature_collection(dummy_data):
     fc = FeatureCollection(feature_descriptors=fd)
 
     assert fc.get_required_series() == ["EDA"]
+    assert fc.get_nb_output_features() == 1
 
     res_list = fc.calculate(dummy_data, return_df=False, n_jobs=1)
     res_df = fc.calculate(dummy_data, return_df=True, n_jobs=1)
@@ -63,6 +64,8 @@ def test_single_series_feature_collection_strides(dummy_data):
 
     assert fc1.get_required_series() == fc2.get_required_series()
     assert fc1.get_required_series() == fc3.get_required_series()
+    assert fc1.get_nb_output_features() == fc2.get_nb_output_features()
+    assert fc1.get_nb_output_features() == fc3.get_nb_output_features()
 
     res1 = fc1.calculate(dummy_data, stride=stride, return_df=False, n_jobs=1)
     res2 = fc2.calculate(dummy_data, stride=stride, return_df=False, n_jobs=1)
@@ -74,145 +77,314 @@ def test_single_series_feature_collection_strides(dummy_data):
     assert_frame_equal(res1[0], res3[0])
 
 
-def test_single_series_feature_collection_sequence_setpoints(dummy_data):
+def test_single_series_feature_collection_sequence_segment_start_idxs(dummy_data):
     dummy_data = dummy_data.reset_index(drop=True)
-    setpoints = [0, 5, 7, 10]
+    segment_start_idxs = [0, 5, 7, 10]
     fd1 = FeatureDescriptor(np.sum, series_name="EDA", window=10)
     fd2 = FeatureDescriptor(np.sum, series_name="EDA", window=10, stride=20)
     fc1 = FeatureCollection(feature_descriptors=fd1)
     fc2 = FeatureCollection(feature_descriptors=fd2)
 
     assert fc1.get_required_series() == fc2.get_required_series()
+    assert fc1.get_nb_output_features() == fc2.get_nb_output_features()
 
-    res1 = fc1.calculate(dummy_data, setpoints=setpoints, window_idx="begin")
-    res2 = fc2.calculate(dummy_data, setpoints=setpoints, window_idx="begin")
+    res1 = fc1.calculate(dummy_data, segment_start_idxs=segment_start_idxs, window_idx="begin")
+    res2 = fc2.calculate(dummy_data, segment_start_idxs=segment_start_idxs, window_idx="begin")
 
     assert (len(res1) == 1) & (len(res2) == 1)
     assert (len(res1[0]) == 4) & (len(res2[0]) == 4)
 
     assert_frame_equal(res1[0], res2[0])
-    assert all(res1[0].index.values == setpoints)
+    assert all(res1[0].index.values == segment_start_idxs)
 
 
-def test_single_series_feature_collection_timestamp_setpoints(dummy_data):
-    setpoints = [0, 5, 7, 10]
-    setpoints = dummy_data.index[setpoints].values
+def test_single_series_feature_collection_sequence_segment_end_idxs(dummy_data):
+    dummy_data = dummy_data.reset_index(drop=True)
+    segment_end_idxs = [20, 25, 35, 40]
+    fd1 = FeatureDescriptor(np.sum, series_name="EDA", window=10)
+    fd2 = FeatureDescriptor(np.sum, series_name="EDA", window=10, stride=20)
+    fc1 = FeatureCollection(feature_descriptors=fd1)
+    fc2 = FeatureCollection(feature_descriptors=fd2)
+
+    assert fc1.get_required_series() == fc2.get_required_series()
+    assert fc1.get_nb_output_features() == fc2.get_nb_output_features()
+
+    res1 = fc1.calculate(dummy_data, segment_end_idxs=segment_end_idxs, window_idx="end")
+    res2 = fc2.calculate(dummy_data, segment_end_idxs=segment_end_idxs, window_idx="end")
+
+    assert (len(res1) == 1) & (len(res2) == 1)
+    assert (len(res1[0]) == 4) & (len(res2[0]) == 4)
+
+    assert_frame_equal(res1[0], res2[0])
+    assert all(res1[0].index.values == segment_end_idxs)
+
+
+def test_single_series_feature_collection_timestamp_segment_start_idxs(dummy_data):
+    segment_start_idxs = [0, 5, 7, 10]
+    segment_start_idxs = dummy_data.index[segment_start_idxs].values
     fd1 = FeatureDescriptor(np.sum, series_name="EDA", window="10s")
     fd2 = FeatureDescriptor(np.sum, series_name="EDA", window="10s", stride='20s')
     fc1 = FeatureCollection(feature_descriptors=fd1)
     fc2 = FeatureCollection(feature_descriptors=fd2)
 
     assert fc1.get_required_series() == fc2.get_required_series()
+    assert fc1.get_nb_output_features() == fc2.get_nb_output_features()
 
-    res1 = fc1.calculate(dummy_data, setpoints=setpoints, window_idx="begin")
-    res2 = fc2.calculate(dummy_data, setpoints=setpoints, window_idx="begin")
+    res1 = fc1.calculate(dummy_data, segment_start_idxs=segment_start_idxs, window_idx="begin")
+    res2 = fc2.calculate(dummy_data, segment_start_idxs=segment_start_idxs, window_idx="begin")
 
     assert (len(res1) == 1) & (len(res2) == 1)
     assert (len(res1[0]) == 4) & (len(res2[0]) == 4)
 
     assert_frame_equal(res1[0], res2[0])
-    assert all(res1[0].index.values == setpoints)
+    assert all(res1[0].index.values == segment_start_idxs)
 
 
-def test_single_series_feature_collection_sequence_setpoints_datatypes():
+def test_single_series_feature_collection_timestamp_segment_end_idxs(dummy_data):
+    segment_end_idxs = [2000, 2500, 3500, 4000]
+    segment_end_idxs = dummy_data.index[segment_end_idxs].values
+    fd1 = FeatureDescriptor(np.sum, series_name="EDA", window="10s")
+    fd2 = FeatureDescriptor(np.sum, series_name="EDA", window="10s", stride='20s')
+    fc1 = FeatureCollection(feature_descriptors=fd1)
+    fc2 = FeatureCollection(feature_descriptors=fd2)
+
+    assert fc1.get_required_series() == fc2.get_required_series()
+    assert fc1.get_nb_output_features() == fc2.get_nb_output_features()
+
+    res1 = fc1.calculate(dummy_data, segment_end_idxs=segment_end_idxs, window_idx="end")
+    res2 = fc2.calculate(dummy_data, segment_end_idxs=segment_end_idxs, window_idx="end")
+
+    assert (len(res1) == 1) & (len(res2) == 1)
+    assert (len(res1[0]) == 4) & (len(res2[0]) == 4)
+
+    assert_frame_equal(res1[0], res2[0])
+    assert all(res1[0].index.values == segment_end_idxs)
+
+
+def test_single_series_feature_collection_sequence_segment_start_idxs_datatypes():
     s = pd.Series(np.arange(20), name="dummy")
-    setpoints_list = [0, 3, 5, 6, 8]
+    segment_start_idxs_list = [0, 3, 5, 6, 8]
 
     fc = FeatureCollection(
         FeatureDescriptor(np.min, "dummy", 5)
     )
 
     # On a list
-    setpoints = setpoints_list
-    assert isinstance(setpoints, list)
-    res = fc.calculate(s, setpoints=setpoints, window_idx="begin", return_df=True)
-    assert np.all(res.index == s.index[setpoints_list])
+    segment_start_idxs = segment_start_idxs_list
+    assert isinstance(segment_start_idxs, list)
+    res = fc.calculate(s, segment_start_idxs=segment_start_idxs, window_idx="begin", return_df=True)
+    assert np.all(res.index == s.index[segment_start_idxs_list])
 
     # On a numpy array
-    setpoints = np.array(setpoints_list)
-    assert isinstance(setpoints, np.ndarray)
-    res = fc.calculate(s, setpoints=setpoints, window_idx="begin", return_df=True)
-    assert np.all(res.index == s.index[setpoints_list])
+    segment_start_idxs = np.array(segment_start_idxs_list)
+    assert isinstance(segment_start_idxs, np.ndarray)
+    res = fc.calculate(s, segment_start_idxs=segment_start_idxs, window_idx="begin", return_df=True)
+    assert np.all(res.index == s.index[segment_start_idxs_list])
 
     # On a pandas series
-    setpoints = pd.Series(setpoints_list)
-    assert isinstance(setpoints, pd.Series)
-    res = fc.calculate(s, setpoints=setpoints, window_idx="begin", return_df=True)
-    assert np.all(res.index == s.index[setpoints_list])
+    segment_start_idxs = pd.Series(segment_start_idxs_list)
+    assert isinstance(segment_start_idxs, pd.Series)
+    res = fc.calculate(s, segment_start_idxs=segment_start_idxs, window_idx="begin", return_df=True)
+    assert np.all(res.index == s.index[segment_start_idxs_list])
 
     # On a pandas dataframe
-    setpoints = pd.DataFrame(setpoints_list)
-    assert isinstance(setpoints, pd.DataFrame)
-    res = fc.calculate(s, setpoints=setpoints, window_idx="begin", return_df=True)
-    assert np.all(res.index == s.index[setpoints_list])
+    segment_start_idxs = pd.DataFrame(segment_start_idxs_list)
+    assert isinstance(segment_start_idxs, pd.DataFrame)
+    res = fc.calculate(s, segment_start_idxs=segment_start_idxs, window_idx="begin", return_df=True)
+    assert np.all(res.index == s.index[segment_start_idxs_list])
 
     # On a pandas index
-    setpoints = pd.Index(setpoints_list)
-    assert isinstance(setpoints, pd.Index)
-    res = fc.calculate(s, setpoints=setpoints, window_idx="begin", return_df=True)
-    assert np.all(res.index == s.index[setpoints_list])
+    segment_start_idxs = pd.Index(segment_start_idxs_list)
+    assert isinstance(segment_start_idxs, pd.Index)
+    res = fc.calculate(s, segment_start_idxs=segment_start_idxs, window_idx="begin", return_df=True)
+    assert np.all(res.index == s.index[segment_start_idxs_list])
 
 
-def test_single_series_feature_collection_timestamp_setpoints_datatypes():
+def test_single_series_feature_collection_sequence_segment_end_idxs_datatypes():
+    s = pd.Series(np.arange(20), name="dummy")
+    segment_end_idxs_list = [5, 6, 8, 12, 18]
+
+    fc = FeatureCollection(
+        FeatureDescriptor(np.min, "dummy", 5)
+    )
+
+    # On a list
+    segment_end_idxs = segment_end_idxs_list
+    assert isinstance(segment_end_idxs, list)
+    res = fc.calculate(s, segment_end_idxs=segment_end_idxs, window_idx="end", return_df=True)
+    assert np.all(res.index == s.index[segment_end_idxs_list])
+
+    # On a numpy array
+    segment_end_idxs = np.array(segment_end_idxs_list)
+    assert isinstance(segment_end_idxs, np.ndarray)
+    res = fc.calculate(s, segment_end_idxs=segment_end_idxs, window_idx="end", return_df=True)
+    assert np.all(res.index == s.index[segment_end_idxs_list])
+
+    # On a pandas series
+    segment_end_idxs = pd.Series(segment_end_idxs_list)
+    assert isinstance(segment_end_idxs, pd.Series)
+    res = fc.calculate(s, segment_end_idxs=segment_end_idxs, window_idx="end", return_df=True)
+    assert np.all(res.index == s.index[segment_end_idxs_list])
+
+    # On a pandas dataframe
+    segment_end_idxs = pd.DataFrame(segment_end_idxs_list)
+    assert isinstance(segment_end_idxs, pd.DataFrame)
+    res = fc.calculate(s, segment_end_idxs=segment_end_idxs, window_idx="end", return_df=True)
+    assert np.all(res.index == s.index[segment_end_idxs_list])
+
+    # On a pandas index
+    segment_end_idxs = pd.Index(segment_end_idxs_list)
+    assert isinstance(segment_end_idxs, pd.Index)
+    res = fc.calculate(s, segment_end_idxs=segment_end_idxs, window_idx="end", return_df=True)
+    assert np.all(res.index == s.index[segment_end_idxs_list])
+
+
+def test_single_series_feature_collection_timestamp_segment_start_idxs_datatypes():
     s = pd.Series(np.arange(20), name="dummy")
     s.index = pd.date_range("2021-08-09", freq="1h", periods=20)
-    setpoints_list = [0, 3, 5, 6, 8]
+    segment_start_idxs_list = [5, 6, 8, 12, 18]
 
     fc = FeatureCollection(
         FeatureDescriptor(np.min, "dummy", "1h")
     )
 
     # On a list
-    setpoints = [s.index[idx] for idx in setpoints_list]
-    res = fc.calculate(s, setpoints=setpoints, window_idx="begin", return_df=True, n_jobs=0)
-    assert np.all(res.index == s.index[setpoints_list])
+    segment_start_idxs = [s.index[idx] for idx in segment_start_idxs_list]
+    res = fc.calculate(s, segment_start_idxs=segment_start_idxs, window_idx="begin", return_df=True, n_jobs=0)
+    assert np.all(res.index == s.index[segment_start_idxs_list])
 
     # On a numpy array
-    setpoints = s.index[setpoints_list].values
-    assert isinstance(setpoints, np.ndarray)
-    res = fc.calculate(s, setpoints=setpoints, window_idx="begin", return_df=True)
-    assert np.all(res.index == s.index[setpoints_list])
+    segment_start_idxs = s.index[segment_start_idxs_list].values
+    assert isinstance(segment_start_idxs, np.ndarray)
+    res = fc.calculate(s, segment_start_idxs=segment_start_idxs, window_idx="begin", return_df=True)
+    assert np.all(res.index == s.index[segment_start_idxs_list])
 
     # On a pandas series
-    setpoints = pd.Series(s.index[setpoints_list])
-    assert isinstance(setpoints, pd.Series)
-    res = fc.calculate(s, setpoints=setpoints, window_idx="begin", return_df=True)
-    assert np.all(res.index == s.index[setpoints_list])
+    segment_start_idxs = pd.Series(s.index[segment_start_idxs_list])
+    assert isinstance(segment_start_idxs, pd.Series)
+    res = fc.calculate(s, segment_start_idxs=segment_start_idxs, window_idx="begin", return_df=True)
+    assert np.all(res.index == s.index[segment_start_idxs_list])
 
     # On a pandas dataframe
-    setpoints = pd.DataFrame(s.index[setpoints_list])
-    assert isinstance(setpoints, pd.DataFrame)
-    res = fc.calculate(s, setpoints=setpoints, window_idx="begin", return_df=True)
-    assert np.all(res.index == s.index[setpoints_list])
+    segment_start_idxs = pd.DataFrame(s.index[segment_start_idxs_list])
+    assert isinstance(segment_start_idxs, pd.DataFrame)
+    res = fc.calculate(s, segment_start_idxs=segment_start_idxs, window_idx="begin", return_df=True)
+    assert np.all(res.index == s.index[segment_start_idxs_list])
 
     # On a pandas index
-    setpoints = s.index[setpoints_list]
-    assert isinstance(setpoints, pd.Index)
-    res = fc.calculate(s, setpoints=setpoints, window_idx="begin", return_df=True)
-    assert np.all(res.index == s.index[setpoints_list])
+    segment_start_idxs = s.index[segment_start_idxs_list]
+    assert isinstance(segment_start_idxs, pd.Index)
+    res = fc.calculate(s, segment_start_idxs=segment_start_idxs, window_idx="begin", return_df=True)
+    assert np.all(res.index == s.index[segment_start_idxs_list])
 
 
-def test_sequence_setpoints_not_sorted():
-    s = pd.Series(np.arange(20), name="dummy")
-    setpoints = [0, 5, 3]
-
-    fc = FeatureCollection(
-        FeatureDescriptor(np.min, "dummy", 5)
-    )
-    res = fc.calculate(s, setpoints=setpoints, return_df=True, window_idx="begin")
-    assert all(res.index == setpoints)
-
-
-def test_time_setpoints_not_sorted():
+def test_single_series_feature_collection_timestamp_segment_end_idxs_datatypes():
     s = pd.Series(np.arange(20), name="dummy")
     s.index = pd.date_range("2021-08-09", freq="1h", periods=20)
-    setpoints = s.index[[0, 5, 3]]
+    segment_end_idxs_list = [5, 6, 8, 12, 18]
 
     fc = FeatureCollection(
         FeatureDescriptor(np.min, "dummy", "1h")
     )
-    res = fc.calculate(s, setpoints=setpoints, return_df=True, window_idx="begin")
-    assert all(res.index == setpoints)
+
+    # On a list
+    segment_end_idxs = [s.index[idx] for idx in segment_end_idxs_list]
+    res = fc.calculate(s, segment_end_idxs=segment_end_idxs, window_idx="end", return_df=True, n_jobs=0)
+    assert np.all(res.index == s.index[segment_end_idxs_list])
+
+    # On a numpy array
+    segment_end_idxs = s.index[segment_end_idxs_list].values
+    assert isinstance(segment_end_idxs, np.ndarray)
+    res = fc.calculate(s, segment_end_idxs=segment_end_idxs, window_idx="end", return_df=True)
+    assert np.all(res.index == s.index[segment_end_idxs_list])
+
+    # On a pandas series
+    segment_end_idxs = pd.Series(s.index[segment_end_idxs_list])
+    assert isinstance(segment_end_idxs, pd.Series)
+    res = fc.calculate(s, segment_end_idxs=segment_end_idxs, window_idx="end", return_df=True)
+    assert np.all(res.index == s.index[segment_end_idxs_list])
+
+    # On a pandas dataframe
+    segment_end_idxs = pd.DataFrame(s.index[segment_end_idxs_list])
+    assert isinstance(segment_end_idxs, pd.DataFrame)
+    res = fc.calculate(s, segment_end_idxs=segment_end_idxs, window_idx="end", return_df=True)
+    assert np.all(res.index == s.index[segment_end_idxs_list])
+
+    # On a pandas index
+    segment_end_idxs = s.index[segment_end_idxs_list]
+    assert isinstance(segment_end_idxs, pd.Index)
+    res = fc.calculate(s, segment_end_idxs=segment_end_idxs, window_idx="end", return_df=True)
+    assert np.all(res.index == s.index[segment_end_idxs_list])
+
+
+def test_sequence_segment_start_idxs_not_sorted():
+    s = pd.Series(np.arange(20), name="dummy")
+    segment_start_idxs = [0, 5, 3]
+
+    fc = FeatureCollection(
+        FeatureDescriptor(np.min, "dummy", 5)
+    )
+    res = fc.calculate(s, segment_start_idxs=segment_start_idxs, return_df=True, window_idx="begin")
+    assert all(res.index == segment_start_idxs)
+
+
+def test_sequence_segment_end_idxs_not_sorted():
+    s = pd.Series(np.arange(20), name="dummy")
+    segment_end_idxs = [5, 10, 8]
+
+    fc = FeatureCollection(
+        FeatureDescriptor(np.min, "dummy", 5)
+    )
+    res = fc.calculate(s, segment_end_idxs=segment_end_idxs, return_df=True, window_idx="end")
+    assert all(res.index == segment_end_idxs)
+
+
+def test_time_segment_start_idxs_not_sorted():
+    s = pd.Series(np.arange(20), name="dummy")
+    s.index = pd.date_range("2021-08-09", freq="1h", periods=20)
+    segment_start_idxs = s.index[[0, 5, 3]]
+
+    fc = FeatureCollection(
+        FeatureDescriptor(np.min, "dummy", "1h")
+    )
+    res = fc.calculate(s, segment_start_idxs=segment_start_idxs, return_df=True, window_idx="begin")
+    assert all(res.index == segment_start_idxs)
+
+
+def test_time_segment_end_idxs_not_sorted():
+    s = pd.Series(np.arange(20), name="dummy")
+    s.index = pd.date_range("2021-08-09", freq="1h", periods=20)
+    segment_end_idxs = s.index[[5, 10, 8]]
+
+    fc = FeatureCollection(
+        FeatureDescriptor(np.min, "dummy", "1h")
+    )
+    res = fc.calculate(s, segment_end_idxs=segment_end_idxs, return_df=True, window_idx="end")
+    assert all(res.index == segment_end_idxs)
+
+
+def test_sequence_segment_start_and_end_idxs():
+    s = pd.Series(np.arange(20), name="dummy")
+    segment_start_idxs = [0, 5, 3]
+    segment_end_idxs = [5, 10, 8]
+
+    fc = FeatureCollection(
+        [
+            FeatureDescriptor(np.min, "dummy", 5),
+            FeatureDescriptor(len, "dummy", 5),
+        ]
+    )
+    res = fc.calculate(s, segment_start_idxs=segment_start_idxs, segment_end_idxs=segment_end_idxs, return_df=True, window_idx="begin")
+    assert all(res.index == segment_start_idxs)
+    assert np.all(res.filter(like="min").values.ravel() == segment_start_idxs)
+    assert np.all(res.filter(like="len").values.ravel() == 5)
+
+
+# TODO: 
+# - test index
+# - test end & start idxs
+# - test error when passing stride
+# CODING: window optioneel maken
 
 
 def test_uneven_sampled_series_feature_collection(dummy_data):
@@ -235,6 +407,7 @@ def test_uneven_sampled_series_feature_collection(dummy_data):
 
     assert set(fc.get_required_series()) == set(["EDA", "TMP"])
     assert len(fc.get_required_series()) == 2
+    assert fc.get_nb_output_features() == 3
 
     # Drop some data to obtain an irregular sampling rate
     inp = dummy_data.drop(np.random.choice(dummy_data.index[1:-1], 500, replace=False))
@@ -264,6 +437,7 @@ def test_warning_uneven_sampled_series_feature_collection(dummy_data):
 
     assert set(fc.get_required_series()) == set(["EDA", "TMP"])
     assert len(fc.get_required_series()) == 2
+    assert fc.get_nb_output_features() == 2
     # Drop some data to obtain an irregular sampling rate
     inp = dummy_data.drop(np.random.choice(dummy_data.index[1:-1], 500, replace=False))
 
@@ -330,6 +504,7 @@ def test_window_idx_single_series_feature_collection(dummy_data):
     fc = FeatureCollection(feature_descriptors=fd)
 
     assert fc.get_required_series() == ["EDA"]
+    assert fc.get_nb_output_features() == 1
 
     res_begin = fc.calculate(dummy_data, return_df=True, n_jobs=0, window_idx="begin")
     res_end = fc.calculate(dummy_data, return_df=True, n_jobs=0, window_idx="end")
@@ -346,9 +521,7 @@ def test_window_idx_single_series_feature_collection(dummy_data):
     )
 
     with pytest.raises(Exception):
-        res_not_existing = fc.calculate(
-            dummy_data, n_jobs=0, return_df=True, window_idx="somewhere"
-        )
+        fc.calculate(dummy_data, n_jobs=0, return_df=True, window_idx="somewhere")
 
     assert np.isclose(res_begin.values, res_end.values).all()
     assert np.isclose(res_begin.values, res_middle.values).all()
@@ -383,6 +556,7 @@ def test_multiplefeaturedescriptors_feature_collection(dummy_data):
 
     assert set(fc.get_required_series()) == set(["EDA", "TMP"])
     assert len(fc.get_required_series()) == 2
+    assert fc.get_nb_output_features() == 3 * 2 * 2
 
     res_list = fc.calculate(dummy_data, return_df=False, n_jobs=6)
     res_df = fc.calculate(dummy_data, return_df=True, n_jobs=6)
@@ -436,7 +610,7 @@ def test_multiplefeaturedescriptors_feature_collection(dummy_data):
 def test_multiplefeaturedescriptors_feature_collection_strides(dummy_data):
     stride= "2.5s"
     mfd1 = MultipleFeatureDescriptors([np.max, np.min], ["EDA", "TMP"], ["5s", "7.5s"])
-    mfd2 = MultipleFeatureDescriptors([np.max, np.min], ["EDA", "TMP"], ["5s", "7.5s"], strides=["5s"])#, "10s"])  # TODO: list of strides supporten...
+    mfd2 = MultipleFeatureDescriptors([np.max, np.min], ["EDA", "TMP"], ["5s", "7.5s"], strides=["5s", "10s"]) 
     mfd3 = MultipleFeatureDescriptors([np.max, np.min], ["EDA", "TMP"], ["5s", "7.5s"], strides=stride)
     fc1 = FeatureCollection(mfd1)
     fc2 = FeatureCollection(mfd2)
@@ -444,6 +618,8 @@ def test_multiplefeaturedescriptors_feature_collection_strides(dummy_data):
 
     assert fc1.get_required_series() == fc2.get_required_series()
     assert fc1.get_required_series() == fc3.get_required_series()
+    assert fc1.get_nb_output_features() == fc2.get_nb_output_features()
+    assert fc1.get_nb_output_features() == fc3.get_nb_output_features()
 
     res1 = fc1.calculate(dummy_data, stride=stride, return_df=True, n_jobs=0)
     res2 = fc2.calculate(dummy_data, stride=stride, return_df=True, n_jobs=0)
@@ -463,6 +639,7 @@ def test_featurecollection_feature_collection(dummy_data):
     fc = FeatureCollection(FeatureCollection(feature_descriptors=fd))
 
     assert fc.get_required_series() == ["EDA"]
+    assert fc.get_nb_output_features() == 1
 
     res_list = fc.calculate(dummy_data, return_df=False, n_jobs=1)
     res_df = fc.calculate(dummy_data, return_df=True, n_jobs=1)
@@ -488,6 +665,10 @@ def test_feature_collection_column_sorted(dummy_data):
         )
     )
     df_eda = dummy_data["EDA"].first('5min')
+
+    assert fc.get_required_series() == ["EDA"]
+    assert fc.get_nb_output_features() == 7 * 3
+
     out_cols = fc.calculate(df_eda, return_df=True, n_jobs=None).columns.values
 
     for _ in range(10):
@@ -623,6 +804,10 @@ def test_featurecollection_reduce_multiple_feat_output(dummy_data):
             fd,
         ]
     )
+
+    assert fc.get_required_series() == ["EDA"]
+    assert fc.get_nb_output_features() == 2 * 3 + 2
+
     # df_feat_tot = fc.calculate(data=dummy_data, return_df=True, show_progress=True)
 
     fc_reduce = fc.reduce(feat_cols_to_keep=["EDA__min__w=5s"])
@@ -1621,19 +1806,19 @@ def test_vectorized_multiple_asynchronous_strides(dummy_data):
         fc.calculate(df_eda)
 
 
-def test_error_pass_stride_and_setpoints_calculate(dummy_data):
-    setpoints = [0, 5, 7, 10]
-    setpoints = dummy_data.index[setpoints].values
+def test_error_pass_stride_and_segment_start_idxs_calculate(dummy_data):
+    segment_start_idxs = [0, 5, 7, 10]
+    segment_start_idxs = dummy_data.index[segment_start_idxs].values
     fc = FeatureCollection(
         FeatureDescriptor(np.min, "EDA", window="5min", stride="3min")
     )
 
-    # Fails because both a stride and setpoints is passed to the calculate method
+    # Fails because both a stride and segment_start_idxs is passed to the calculate method
     with pytest.raises(Exception):
-        fc.calculate(dummy_data["EDA"], stride="3min", setpoints=setpoints)
+        fc.calculate(dummy_data["EDA"], stride="3min", segment_start_idxs=segment_start_idxs)
 
 
-def test_error_no_stride_and_no_setpoints(dummy_data):
+def test_error_no_stride_and_no_segment_start_idxs(dummy_data):
     fc = FeatureCollection(
         [
             FeatureDescriptor(np.min, "EDA", window="5s"),
@@ -1642,7 +1827,7 @@ def test_error_no_stride_and_no_setpoints(dummy_data):
     )
 
     # Fails because at least one feature descriptor in the feature collection does not
-    # have a stride, and no stride nor setpoints is passed to the calculate method
+    # have a stride, and no stride nor segment_start_idxs is passed to the calculate method
     with pytest.raises(Exception):
         fc.calculate(dummy_data)
 
@@ -1690,8 +1875,8 @@ def test_feature_collection_various_timezones_data():
         fc.calculate([s_usa, s_eu, s_none])
 
 
-def test_feature_collection_various_timezones_setpoints():
-    # TODO: do we really want to support setpoints with different time zones?
+def test_feature_collection_various_timezones_segment_start_idxs():
+    # TODO: do we really want to support segment_start_idxs with different time zones?
     s_usa = pd.Series(
         [0, 1, 2, 3, 4, 5], 
         index=pd.date_range("2020-01-01", freq="1h", periods=6, tz='America/Chicago'),
@@ -1713,17 +1898,17 @@ def test_feature_collection_various_timezones_setpoints():
         fc = FeatureCollection(
             FeatureDescriptor(np.min, s.name, "3h", "3h")
         )
-        res = fc.calculate([s_usa, s_eu, s_none], setpoints=s.index[:3], n_jobs=0, return_df=True)
+        res = fc.calculate([s_usa, s_eu, s_none], segment_start_idxs=s.index[:3], n_jobs=0, return_df=True)
         assert np.all(res.values.ravel() == [0, 1, 2])
 
     fc = FeatureCollection(
         FeatureDescriptor(np.min, "s_usa", "3h", "3h")
     )
-    res = fc.calculate(s_usa, setpoints=s_eu.index[:3].values, n_jobs=0, return_df=True)
+    res = fc.calculate(s_usa, segment_start_idxs=s_eu.index[:3].values, n_jobs=0, return_df=True)
     assert np.all(res.values == [])
 
     fc = FeatureCollection(
         FeatureDescriptor(np.min, "s_usa", "3h", "3h")
     )
-    res = fc.calculate(s_usa, setpoints=s_none.index[:3].values, n_jobs=0, return_df=True)
+    res = fc.calculate(s_usa, segment_start_idxs=s_none.index[:3].values, n_jobs=0, return_df=True)
     assert np.all(res.values == [])

--- a/tests/test_features_feature_collection.py
+++ b/tests/test_features_feature_collection.py
@@ -370,14 +370,32 @@ def test_sequence_segment_start_and_end_idxs():
 
     fc = FeatureCollection(
         [
-            FeatureDescriptor(np.min, "dummy", 5),
-            FeatureDescriptor(len, "dummy", 5),
+            FeatureDescriptor(np.min, "dummy", 100),
+            FeatureDescriptor(len, "dummy"),
         ]
     )
     res = fc.calculate(s, segment_start_idxs=segment_start_idxs, segment_end_idxs=segment_end_idxs, return_df=True, window_idx="begin")
     assert all(res.index == segment_start_idxs)
-    assert np.all(res.filter(like="min").values.ravel() == segment_start_idxs)
-    assert np.all(res.filter(like="len").values.ravel() == 5)
+    assert np.all(res["dummy__amin__w=manual"] == segment_start_idxs)
+    assert np.all(res["dummy__len__w=manual"] == 5)
+
+
+def test_time_segment_start_and_end_idxs():
+    s = pd.Series(np.arange(20), name="dummy")
+    s.index = pd.date_range("2021-08-09", freq="1h", periods=20)
+    segment_start_idxs = s.index[[0, 5, 3]]
+    segment_end_idxs = s.index[[5, 10, 8]]
+
+    fc = FeatureCollection(
+        [
+            FeatureDescriptor(np.min, "dummy", "100h"),
+            FeatureDescriptor(len, "dummy"),
+        ]
+    )
+    res = fc.calculate(s, segment_start_idxs=segment_start_idxs, segment_end_idxs=segment_end_idxs, return_df=True, window_idx="begin")
+    assert all(res.index == segment_start_idxs)
+    assert np.all(res["dummy__amin__w=manual"] == [0, 5, 3])
+    assert np.all(res["dummy__len__w=manual"] == 5)
 
 
 # TODO: 

--- a/tests/test_features_logging.py
+++ b/tests/test_features_logging.py
@@ -112,7 +112,7 @@ def test_simple_features_logging_sequence_index(dummy_data, logging_file_path):
     assert series_names_df["duration"]["count"].sum() == 4
 
 
-def test_simple_features_logging_setpoints_no_stride(dummy_data, logging_file_path):
+def test_simple_features_logging_segment_start_idxs_no_stride(dummy_data, logging_file_path):
     # Add no stride
     dummy_data = dummy_data.reset_index(drop=True)
     fd = FeatureDescriptor(
@@ -132,8 +132,8 @@ def test_simple_features_logging_setpoints_no_stride(dummy_data, logging_file_pa
     assert not os.path.exists(logging_file_path)
 
     # Sequential (n_jobs <= 1), otherwise file_path gets cleared
-    setpoints = np.arange(0, 1300, 130)
-    _ = fc.calculate(dummy_data, setpoints=setpoints, logging_file_path=logging_file_path, n_jobs=1)
+    segment_start_idxs = np.arange(0, 1300, 130)
+    _ = fc.calculate(dummy_data, segment_start_idxs=segment_start_idxs, logging_file_path=logging_file_path, n_jobs=1)
 
     assert os.path.exists(logging_file_path)
     logging_df = get_feature_logs(logging_file_path)
@@ -147,22 +147,73 @@ def test_simple_features_logging_setpoints_no_stride(dummy_data, logging_file_pa
     assert set(logging_df["function"].values) == set(['amin', 'sum'])
     assert set(logging_df["series_names"].values) == set(["(EDA,)", "(ACC_x,)", "(TMP,)"])
     assert all(logging_df["window"] == 50)
-    assert all(logging_df["stride"] == tuple())
+    assert all(logging_df["stride"] == "manual")
 
     function_stats_df = get_function_stats(logging_file_path)
     assert len(function_stats_df) == 2
-    assert set(function_stats_df.index) == set([(s, 50, tuple()) for s in ["sum", "amin"]])
+    assert set(function_stats_df.index) == set([(s, 50, "manual") for s in ["sum", "amin"]])
     assert all(function_stats_df["duration"]["mean"] > 0)
     assert function_stats_df["duration"]["count"].sum() == 4
 
     series_names_df = get_series_names_stats(logging_file_path)
     assert len(series_names_df) == 3
-    assert set(series_names_df.index) == set([(s, 50, tuple()) for s in ["(EDA,)", "(TMP,)", "(ACC_x,)"]])
+    assert set(series_names_df.index) == set([(s, 50, "manual") for s in ["(EDA,)", "(TMP,)", "(ACC_x,)"]])
     assert all(series_names_df["duration"]["mean"] > 0)
     assert series_names_df["duration"]["count"].sum() == 4
 
 
-def test_simple_features_logging_setpoints_overrule_stride(dummy_data, logging_file_path):
+
+def test_simple_features_logging_segment_end_idxs_no_stride(dummy_data, logging_file_path):
+    # Add no stride
+    dummy_data = dummy_data.reset_index(drop=True)
+    fd = FeatureDescriptor(
+        function=np.sum,
+        series_name="EDA",
+        window=50,
+    )
+    fc = FeatureCollection(feature_descriptors=fd)
+    fc.add(MultipleFeatureDescriptors(np.min, series_names=["TMP","ACC_x"], windows=50))
+    fc.add(FeatureDescriptor(np.min, series_name=("EDA",), window=50))
+    for fd in flatten(fc._feature_desc_dict.values()):
+        assert fd.stride is None
+
+    assert set(fc.get_required_series()) == set(["EDA", "TMP", "ACC_x"])
+    assert len(fc.get_required_series()) == 3
+
+    assert not os.path.exists(logging_file_path)
+
+    # Sequential (n_jobs <= 1), otherwise file_path gets cleared
+    segment_end_idxs = np.arange(50, 1350, 130)
+    _ = fc.calculate(dummy_data, segment_end_idxs=segment_end_idxs, logging_file_path=logging_file_path, n_jobs=1)
+
+    assert os.path.exists(logging_file_path)
+    logging_df = get_feature_logs(logging_file_path)
+
+    assert all(logging_df.columns.values == ['log_time', 'function', 'series_names', 'window', 'stride', 'duration'])
+
+    assert len(logging_df) == 4
+    assert logging_df.select_dtypes(include=[np.datetime64]).columns.values == ['log_time']
+    assert logging_df.select_dtypes(include=[np.timedelta64]).columns.values == ['duration']
+
+    assert set(logging_df["function"].values) == set(['amin', 'sum'])
+    assert set(logging_df["series_names"].values) == set(["(EDA,)", "(ACC_x,)", "(TMP,)"])
+    assert all(logging_df["window"] == 50)
+    assert all(logging_df["stride"] == "manual")
+
+    function_stats_df = get_function_stats(logging_file_path)
+    assert len(function_stats_df) == 2
+    assert set(function_stats_df.index) == set([(s, 50, "manual") for s in ["sum", "amin"]])
+    assert all(function_stats_df["duration"]["mean"] > 0)
+    assert function_stats_df["duration"]["count"].sum() == 4
+
+    series_names_df = get_series_names_stats(logging_file_path)
+    assert len(series_names_df) == 3
+    assert set(series_names_df.index) == set([(s, 50, "manual") for s in ["(EDA,)", "(TMP,)", "(ACC_x,)"]])
+    assert all(series_names_df["duration"]["mean"] > 0)
+    assert series_names_df["duration"]["count"].sum() == 4
+
+
+def test_simple_features_logging_segment_start_idxs_overrule_stride(dummy_data, logging_file_path):
     # Add no stride
     dummy_data = dummy_data.reset_index(drop=True)
     fd = FeatureDescriptor(
@@ -183,8 +234,8 @@ def test_simple_features_logging_setpoints_overrule_stride(dummy_data, logging_f
     assert not os.path.exists(logging_file_path)
 
     # Sequential (n_jobs <= 1), otherwise file_path gets cleared
-    setpoints = np.arange(0, 1200, 120)
-    _ = fc.calculate(dummy_data, setpoints=setpoints, logging_file_path=logging_file_path, n_jobs=1)
+    segment_start_idxs = np.arange(0, 1200, 120)
+    _ = fc.calculate(dummy_data, segment_start_idxs=segment_start_idxs, logging_file_path=logging_file_path, n_jobs=1)
 
     assert os.path.exists(logging_file_path)
     logging_df = get_feature_logs(logging_file_path)
@@ -198,17 +249,120 @@ def test_simple_features_logging_setpoints_overrule_stride(dummy_data, logging_f
     assert set(logging_df["function"].values) == set(['amin', 'sum'])
     assert set(logging_df["series_names"].values) == set(["(EDA,)", "(ACC_x,)", "(TMP,)"])
     assert all(logging_df["window"] == 50)
-    assert all(logging_df["stride"] == tuple())
+    assert all(logging_df["stride"] == "manual")
 
     function_stats_df = get_function_stats(logging_file_path)
     assert len(function_stats_df) == 2
-    assert set(function_stats_df.index) == set([(s, 50, tuple()) for s in ["sum", "amin"]])
+    assert set(function_stats_df.index) == set([(s, 50, "manual") for s in ["sum", "amin"]])
     assert all(function_stats_df["duration"]["mean"] > 0)
     assert function_stats_df["duration"]["count"].sum() == 4
 
     series_names_df = get_series_names_stats(logging_file_path)
     assert len(series_names_df) == 3
-    assert set(series_names_df.index) == set([(s, 50, tuple()) for s in ["(EDA,)", "(TMP,)", "(ACC_x,)"]])
+    assert set(series_names_df.index) == set([(s, 50, "manual") for s in ["(EDA,)", "(TMP,)", "(ACC_x,)"]])
+    assert all(series_names_df["duration"]["mean"] > 0)
+    assert series_names_df["duration"]["count"].sum() == 4
+
+
+def test_simple_features_logging_segment_end_idxs_overrule_stride(dummy_data, logging_file_path):
+    # Add no stride
+    dummy_data = dummy_data.reset_index(drop=True)
+    fd = FeatureDescriptor(
+        function=np.sum,
+        series_name="EDA",
+        window=50,
+        stride=120,
+    )
+    fc = FeatureCollection(feature_descriptors=fd)
+    fc.add(MultipleFeatureDescriptors(np.min, series_names=["TMP","ACC_x"], windows=50, strides=20))
+    fc.add(FeatureDescriptor(np.min, series_name=("EDA",), window=50, stride=34))
+    for fd in flatten(fc._feature_desc_dict.values()):
+        assert fd.stride is not None
+
+    assert set(fc.get_required_series()) == set(["EDA", "TMP", "ACC_x"])
+    assert len(fc.get_required_series()) == 3
+
+    assert not os.path.exists(logging_file_path)
+
+    # Sequential (n_jobs <= 1), otherwise file_path gets cleared
+    segment_end_idxs = np.arange(50, 1250, 120)
+    _ = fc.calculate(dummy_data, segment_end_idxs=segment_end_idxs, logging_file_path=logging_file_path, n_jobs=1)
+
+    assert os.path.exists(logging_file_path)
+    logging_df = get_feature_logs(logging_file_path)
+
+    assert all(logging_df.columns.values == ['log_time', 'function', 'series_names', 'window', 'stride', 'duration'])
+
+    assert len(logging_df) == 4
+    assert logging_df.select_dtypes(include=[np.datetime64]).columns.values == ['log_time']
+    assert logging_df.select_dtypes(include=[np.timedelta64]).columns.values == ['duration']
+
+    assert set(logging_df["function"].values) == set(['amin', 'sum'])
+    assert set(logging_df["series_names"].values) == set(["(EDA,)", "(ACC_x,)", "(TMP,)"])
+    assert all(logging_df["window"] == 50)
+    assert all(logging_df["stride"] == "manual")
+
+    function_stats_df = get_function_stats(logging_file_path)
+    assert len(function_stats_df) == 2
+    assert set(function_stats_df.index) == set([(s, 50, "manual") for s in ["sum", "amin"]])
+    assert all(function_stats_df["duration"]["mean"] > 0)
+    assert function_stats_df["duration"]["count"].sum() == 4
+
+    series_names_df = get_series_names_stats(logging_file_path)
+    assert len(series_names_df) == 3
+    assert set(series_names_df.index) == set([(s, 50, "manual") for s in ["(EDA,)", "(TMP,)", "(ACC_x,)"]])
+    assert all(series_names_df["duration"]["mean"] > 0)
+    assert series_names_df["duration"]["count"].sum() == 4
+
+
+def test_simple_features_logging_segment_start_and_end_idxs_overrule_stride_and_window(dummy_data, logging_file_path):
+    # Add no stride
+    dummy_data = dummy_data.reset_index(drop=True)
+    fd = FeatureDescriptor(
+        function=np.sum,
+        series_name="EDA",
+        window=50,
+        stride=120,
+    )
+    fc = FeatureCollection(feature_descriptors=fd)
+    fc.add(MultipleFeatureDescriptors(np.min, series_names=["TMP","ACC_x"], windows=50, strides=20))
+    fc.add(FeatureDescriptor(np.min, series_name=("EDA",), window=50, stride=34))
+    for fd in flatten(fc._feature_desc_dict.values()):
+        assert fd.stride is not None
+
+    assert set(fc.get_required_series()) == set(["EDA", "TMP", "ACC_x"])
+    assert len(fc.get_required_series()) == 3
+
+    assert not os.path.exists(logging_file_path)
+
+    # Sequential (n_jobs <= 1), otherwise file_path gets cleared
+    segment_start_idxs = np.arange(0, 1200, 120)
+    segment_end_idxs = segment_start_idxs + 50
+    _ = fc.calculate(dummy_data, segment_start_idxs=segment_start_idxs, segment_end_idxs=segment_end_idxs, logging_file_path=logging_file_path, n_jobs=1)
+
+    assert os.path.exists(logging_file_path)
+    logging_df = get_feature_logs(logging_file_path)
+
+    assert all(logging_df.columns.values == ['log_time', 'function', 'series_names', 'window', 'stride', 'duration'])
+
+    assert len(logging_df) == 4
+    assert logging_df.select_dtypes(include=[np.datetime64]).columns.values == ['log_time']
+    assert logging_df.select_dtypes(include=[np.timedelta64]).columns.values == ['duration']
+
+    assert set(logging_df["function"].values) == set(['amin', 'sum'])
+    assert set(logging_df["series_names"].values) == set(["(EDA,)", "(ACC_x,)", "(TMP,)"])
+    assert all(logging_df["window"] == "manual")
+    assert all(logging_df["stride"] == "manual")
+
+    function_stats_df = get_function_stats(logging_file_path)
+    assert len(function_stats_df) == 2
+    assert set(function_stats_df.index) == set([(s, "manual", "manual") for s in ["sum", "amin"]])
+    assert all(function_stats_df["duration"]["mean"] > 0)
+    assert function_stats_df["duration"]["count"].sum() == 4
+
+    series_names_df = get_series_names_stats(logging_file_path)
+    assert len(series_names_df) == 3
+    assert set(series_names_df.index) == set([(s, "manual", "manual") for s in ["(EDA,)", "(TMP,)", "(ACC_x,)"]])
     assert all(series_names_df["duration"]["mean"] > 0)
     assert series_names_df["duration"]["count"].sum() == 4
 

--- a/tests/test_strided_rolling.py
+++ b/tests/test_strided_rolling.py
@@ -349,140 +349,140 @@ def test_time_stroll_indexing_multiple_strides():
     assert np.all(sr.index == get_time_index([0]))
 
 
-def test_sequence_stroll_indexing_setpoints():
-    setpoints = np.array([0, 5, 7, 10])
+def test_sequence_stroll_indexing_segment_start_idxs():
+    segment_start_idxs = np.array([0, 5, 7, 10])
     s = pd.Series(data=np.arange(20), name="dummy")
 
     ## No Force
-    sr = SequenceStridedRolling(s, window=3, setpoints=setpoints, window_idx="begin")
+    sr = SequenceStridedRolling(s, window=3, segment_start_idxs=segment_start_idxs, window_idx="begin")
     assert sr.strides is None
-    assert np.all(sr.index == setpoints)
+    assert np.all(sr.index == segment_start_idxs)
 
-    sr = SequenceStridedRolling(s, window=3, strides=[3, 5], setpoints=setpoints, window_idx="begin")
+    sr = SequenceStridedRolling(s, window=3, strides=[3, 5], segment_start_idxs=segment_start_idxs, window_idx="begin")
     assert sr.strides is None
-    assert np.all(sr.index == setpoints)
+    assert np.all(sr.index == segment_start_idxs)
 
-    sr = SequenceStridedRolling(s, window=3, strides=[3, 5], setpoints=setpoints, window_idx="end")
+    sr = SequenceStridedRolling(s, window=3, strides=[3, 5], segment_start_idxs=segment_start_idxs, window_idx="end")
     assert sr.strides is None
-    assert np.all(sr.index == setpoints + 3)
+    assert np.all(sr.index == segment_start_idxs + 3)
 
     ## Force
-    sr = SequenceStridedRolling(s, window=3, setpoints=setpoints, window_idx="begin", include_final_window=True)
+    sr = SequenceStridedRolling(s, window=3, segment_start_idxs=segment_start_idxs, window_idx="begin", include_final_window=True)
     assert sr.strides is None
-    assert np.all(sr.index == setpoints)
+    assert np.all(sr.index == segment_start_idxs)
 
-    sr = SequenceStridedRolling(s, window=3, strides=[3, 5], setpoints=setpoints, window_idx="begin", include_final_window=True)
+    sr = SequenceStridedRolling(s, window=3, strides=[3, 5], segment_start_idxs=segment_start_idxs, window_idx="begin", include_final_window=True)
     assert sr.strides is None
-    assert np.all(sr.index == setpoints)
+    assert np.all(sr.index == segment_start_idxs)
 
-    sr = SequenceStridedRolling(s, window=3, strides=[3, 5], setpoints=setpoints, window_idx="end", include_final_window=True)
+    sr = SequenceStridedRolling(s, window=3, strides=[3, 5], segment_start_idxs=segment_start_idxs, window_idx="end", include_final_window=True)
     assert sr.strides is None
-    assert np.all(sr.index == setpoints + 3)
+    assert np.all(sr.index == segment_start_idxs + 3)
 
 
-def test_sequence_stroll_indexing_setpoints_outside_valid_range():
-    setpoints = np.array([0, 5, 7, 10, 200])
+def test_sequence_stroll_indexing_segment_start_idxs_outside_valid_range():
+    segment_start_idxs = np.array([0, 5, 7, 10, 200])
     s = pd.Series(data=np.arange(20), name="dummy")
 
     ## No Force
     ## No Force
-    sr = SequenceStridedRolling(s, window=3, setpoints=setpoints, window_idx="begin")
+    sr = SequenceStridedRolling(s, window=3, segment_start_idxs=segment_start_idxs, window_idx="begin")
     assert sr.strides is None
-    assert np.all(sr.index == setpoints[:4])
+    assert np.all(sr.index == segment_start_idxs[:4])
 
-    sr = SequenceStridedRolling(s, window=3, strides=[3, 5], setpoints=setpoints, window_idx="begin")
+    sr = SequenceStridedRolling(s, window=3, strides=[3, 5], segment_start_idxs=segment_start_idxs, window_idx="begin")
     assert sr.strides is None
-    assert np.all(sr.index == setpoints[:4])
+    assert np.all(sr.index == segment_start_idxs[:4])
 
-    sr = SequenceStridedRolling(s, window=3, strides=[3, 5], setpoints=setpoints, window_idx="end")
+    sr = SequenceStridedRolling(s, window=3, strides=[3, 5], segment_start_idxs=segment_start_idxs, window_idx="end")
     assert sr.strides is None
-    assert np.all(sr.index == setpoints[:4] + 3)
+    assert np.all(sr.index == segment_start_idxs[:4] + 3)
 
     ## Force
-    sr = SequenceStridedRolling(s, window=3, setpoints=setpoints, window_idx="begin", include_final_window=True)
+    sr = SequenceStridedRolling(s, window=3, segment_start_idxs=segment_start_idxs, window_idx="begin", include_final_window=True)
     assert sr.strides is None
-    assert np.all(sr.index == setpoints[:4])
+    assert np.all(sr.index == segment_start_idxs[:4])
 
-    sr = SequenceStridedRolling(s, window=3, strides=[3, 5], setpoints=setpoints, window_idx="begin", include_final_window=True)
+    sr = SequenceStridedRolling(s, window=3, strides=[3, 5], segment_start_idxs=segment_start_idxs, window_idx="begin", include_final_window=True)
     assert sr.strides is None
-    assert np.all(sr.index == setpoints[:4])
+    assert np.all(sr.index == segment_start_idxs[:4])
 
-    sr = SequenceStridedRolling(s, window=3, strides=[3, 5], setpoints=setpoints, window_idx="end", include_final_window=True)
+    sr = SequenceStridedRolling(s, window=3, strides=[3, 5], segment_start_idxs=segment_start_idxs, window_idx="end", include_final_window=True)
     assert sr.strides is None
-    assert np.all(sr.index == setpoints[:4] + 3)
+    assert np.all(sr.index == segment_start_idxs[:4] + 3)
 
 
-def test_time_stroll_indexing_setpoints():
+def test_time_stroll_indexing_segment_start_idxs():
     s = pd.Series(data=np.arange(20), name="dummy")
     time_index = pd.date_range("2020-01-01", freq="1h", periods=20)
     s.index = time_index
 
-    setpoints = s.index[[0, 5, 7, 10]].values
+    segment_start_idxs = s.index[[0, 5, 7, 10]].values
 
     def get_time_index(arr):
         return [time_index[idx] for idx in arr]
 
     ## No Force
-    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), setpoints=setpoints, window_idx="begin")
+    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), segment_start_idxs=segment_start_idxs, window_idx="begin")
     assert sr.strides is None
     assert np.all(sr.index == get_time_index([0, 5, 7, 10]))
 
-    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), strides=[pd.Timedelta(3, unit="h"), pd.Timedelta(5, unit="h")], setpoints=setpoints, window_idx="begin")
+    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), strides=[pd.Timedelta(3, unit="h"), pd.Timedelta(5, unit="h")], segment_start_idxs=segment_start_idxs, window_idx="begin")
     assert sr.strides is None
     assert np.all(sr.index == get_time_index([0, 5, 7, 10]))
 
-    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), strides=[pd.Timedelta(3, unit="h"), pd.Timedelta(5, unit="h")], setpoints=setpoints, window_idx="end")
+    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), strides=[pd.Timedelta(3, unit="h"), pd.Timedelta(5, unit="h")], segment_start_idxs=segment_start_idxs, window_idx="end")
     assert sr.strides is None
     assert np.all(sr.index == [t + pd.Timedelta(3, unit="h") for t in get_time_index([0, 5, 7, 10])])
 
     ## No Force
-    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), setpoints=setpoints, window_idx="begin", include_final_window=True)
+    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), segment_start_idxs=segment_start_idxs, window_idx="begin", include_final_window=True)
     assert sr.strides is None
     assert np.all(sr.index == get_time_index([0, 5, 7, 10]))
 
-    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), strides=[pd.Timedelta(3, unit="h"), pd.Timedelta(5, unit="h")], setpoints=setpoints, window_idx="begin", include_final_window=True)
+    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), strides=[pd.Timedelta(3, unit="h"), pd.Timedelta(5, unit="h")], segment_start_idxs=segment_start_idxs, window_idx="begin", include_final_window=True)
     assert sr.strides is None
     assert np.all(sr.index == get_time_index([0, 5, 7, 10]))
 
-    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), strides=[pd.Timedelta(3, unit="h"), pd.Timedelta(5, unit="h")], setpoints=setpoints, window_idx="end", include_final_window=True)
+    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), strides=[pd.Timedelta(3, unit="h"), pd.Timedelta(5, unit="h")], segment_start_idxs=segment_start_idxs, window_idx="end", include_final_window=True)
     assert sr.strides is None
     assert np.all(sr.index == [t + pd.Timedelta(3, unit="h") for t in get_time_index([0, 5, 7, 10])])
 
 
-def test_time_stroll_indexing_setpoints_outside_valid_range():
+def test_time_stroll_indexing_segment_start_idxs_outside_valid_range():
     s = pd.Series(data=np.arange(20), name="dummy")
     time_index = pd.date_range("2020-01-01", freq="1h", periods=20)
     s.index = time_index
 
-    setpoints = s.index[[0, 5, 7, 10]].values
-    setpoints = np.append(setpoints, (s.index[[0]] + pd.Timedelta(200, unit="h")).values)
+    segment_start_idxs = s.index[[0, 5, 7, 10]].values
+    segment_start_idxs = np.append(segment_start_idxs, (s.index[[0]] + pd.Timedelta(200, unit="h")).values)
 
     def get_time_index(arr):
         return [time_index[idx] for idx in arr]
 
     ## No Force
-    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), setpoints=setpoints, window_idx="begin")
+    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), segment_start_idxs=segment_start_idxs, window_idx="begin")
     assert sr.strides is None
     assert np.all(sr.index == get_time_index([0, 5, 7, 10]))
 
-    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), strides=[pd.Timedelta(3, unit="h"), pd.Timedelta(5, unit="h")], setpoints=setpoints, window_idx="begin")
+    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), strides=[pd.Timedelta(3, unit="h"), pd.Timedelta(5, unit="h")], segment_start_idxs=segment_start_idxs, window_idx="begin")
     assert sr.strides is None
     assert np.all(sr.index == get_time_index([0, 5, 7, 10]))
 
-    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), strides=[pd.Timedelta(3, unit="h"), pd.Timedelta(5, unit="h")], setpoints=setpoints, window_idx="end")
+    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), strides=[pd.Timedelta(3, unit="h"), pd.Timedelta(5, unit="h")], segment_start_idxs=segment_start_idxs, window_idx="end")
     assert sr.strides is None
     assert np.all(sr.index == [t + pd.Timedelta(3, unit="h") for t in get_time_index([0, 5, 7, 10])])
 
     ## No Force
-    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), setpoints=setpoints, window_idx="begin", include_final_window=True)
+    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), segment_start_idxs=segment_start_idxs, window_idx="begin", include_final_window=True)
     assert sr.strides is None
     assert np.all(sr.index == get_time_index([0, 5, 7, 10]))
 
-    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), strides=[pd.Timedelta(3, unit="h"), pd.Timedelta(5, unit="h")], setpoints=setpoints, window_idx="begin", include_final_window=True)
+    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), strides=[pd.Timedelta(3, unit="h"), pd.Timedelta(5, unit="h")], segment_start_idxs=segment_start_idxs, window_idx="begin", include_final_window=True)
     assert sr.strides is None
     assert np.all(sr.index == get_time_index([0, 5, 7, 10]))
 
-    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), strides=[pd.Timedelta(3, unit="h"), pd.Timedelta(5, unit="h")], setpoints=setpoints, window_idx="end", include_final_window=True)
+    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), strides=[pd.Timedelta(3, unit="h"), pd.Timedelta(5, unit="h")], segment_start_idxs=segment_start_idxs, window_idx="end", include_final_window=True)
     assert sr.strides is None
     assert np.all(sr.index == [t + pd.Timedelta(3, unit="h") for t in get_time_index([0, 5, 7, 10])])
 
@@ -602,11 +602,11 @@ def test_time_stroll_apply_func_vectorized():
     assert_1col_df_equal(sr.apply_func(f), sr.apply_func(f_vect))
 
 
-def test_sequence_stroll_apply_func_vectorized_setpoints():
+def test_sequence_stroll_apply_func_vectorized_segment_start_idxs():
     f = FuncWrapper(np.min, output_names="min")
     f_vect = FuncWrapper(np.min, output_names="min_vect", vectorized=True, axis=-1)
 
-    setpoints = np.array([0, 3, 6, 9])
+    segment_start_idxs = np.array([0, 3, 6, 9])
     s = pd.Series(data=np.arange(20), name="dummy")
 
     def assert_1col_df_equal(s1, s2):
@@ -615,27 +615,27 @@ def test_sequence_stroll_apply_func_vectorized_setpoints():
         assert np.all(s1.values.ravel() == s2.values.ravel())
 
     ## No Force
-    sr = SequenceStridedRolling(s, window=3, setpoints=setpoints, window_idx="begin")
+    sr = SequenceStridedRolling(s, window=3, segment_start_idxs=segment_start_idxs, window_idx="begin")
     assert_1col_df_equal(sr.apply_func(f), sr.apply_func(f_vect))
 
     ## Force
-    sr = SequenceStridedRolling(s, window=3, setpoints=setpoints, window_idx="begin", include_final_window=True)
+    sr = SequenceStridedRolling(s, window=3, segment_start_idxs=segment_start_idxs, window_idx="begin", include_final_window=True)
     assert_1col_df_equal(sr.apply_func(f), sr.apply_func(f_vect))
 
     with pytest.raises(Exception):
-        # Because of irregular stride step in the setpoints
-        setpoints = np.array([0, 2, 3])
-        sr = SequenceStridedRolling(s, window=3, setpoints=setpoints, window_idx="begin")
+        # Because of irregular stride step in the segment_start_idxs
+        segment_start_idxs = np.array([0, 2, 3])
+        sr = SequenceStridedRolling(s, window=3, segment_start_idxs=segment_start_idxs, window_idx="begin")
         sr.apply_func(f_vect)
     
 
-def test_time_stroll_apply_func_vectorized_setpoints():
+def test_time_stroll_apply_func_vectorized_segment_start_idxs():
     f = FuncWrapper(np.min, output_names="min")
     f_vect = FuncWrapper(np.min, output_names="min_vect", vectorized=True, axis=-1)
 
     s = pd.Series(data=np.arange(20), name="dummy")
     s.index = pd.date_range("2020-01-01", freq="1h", periods=20)
-    setpoints = s.index[[0, 3, 6, 9]].values
+    segment_start_idxs = s.index[[0, 3, 6, 9]].values
 
     def assert_1col_df_equal(s1, s2):
         assert (s1.shape[1] == 1) & (s2.shape[1] == 1)
@@ -643,17 +643,17 @@ def test_time_stroll_apply_func_vectorized_setpoints():
         assert np.all(s1.values.ravel() == s2.values.ravel())
 
     ## No Force
-    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), setpoints=setpoints, window_idx="begin")
+    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), segment_start_idxs=segment_start_idxs, window_idx="begin")
     assert_1col_df_equal(sr.apply_func(f), sr.apply_func(f_vect))
    
     ## Force
-    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), setpoints=setpoints, window_idx="begin", include_final_window=True)
+    sr = TimeStridedRolling(s, window=pd.Timedelta(3, unit="h"), segment_start_idxs=segment_start_idxs, window_idx="begin", include_final_window=True)
     assert_1col_df_equal(sr.apply_func(f), sr.apply_func(f_vect))
 
     with pytest.raises(Exception):
-        # Because of irregular stride step in the setpoints
-        setpoints = s.index[[0, 2, 3]].values
-        sr = SequenceStridedRolling(s, window=3, setpoints=setpoints, window_idx="begin")
+        # Because of irregular stride step in the segment_start_idxs
+        segment_start_idxs = s.index[[0, 2, 3]].values
+        sr = SequenceStridedRolling(s, window=3, segment_start_idxs=segment_start_idxs, window_idx="begin")
         sr.apply_func(f_vect)
 
 

--- a/tsflex/features/feature_collection.py
+++ b/tsflex/features/feature_collection.py
@@ -301,8 +301,8 @@ class FeatureCollection:
         self,
         data: Union[pd.Series, pd.DataFrame, List[Union[pd.Series, pd.DataFrame]]],
         stride: Optional[Union[float, str, pd.Timedelta, List, None]] = None,
-        segment_start_idxs: Optional[pd.Index] = None,
-        segment_end_idxs: Optional[pd.Index] = None,
+        segment_start_idxs: Optional[Union[list, np.ndarray, pd.Series, pd.Index]] = None,
+        segment_end_idxs: Optional[Union[list, np.ndarray, pd.Series, pd.Index]] = None,
         return_df: Optional[bool] = False,
         window_idx: Optional[str] = "end",
         include_final_window: Optional[bool] = False,
@@ -340,7 +340,7 @@ class FeatureCollection:
                 When set, this stride argument takes precedence over the stride property
                 of the `FeatureDescriptor`s in this `FeatureCollection` (i.e., when a
                 not None value for `stride` passed to this method).
-        segment_start_idxs: pd.Index, optional  # TODO is this a pd.Index?
+        segment_start_idxs: Union[list, np.ndarray, pd.Series, pd.Index], optional
             The start indices of the segments. If None, the start indices will be
             computed from the data using either
             - the `segment_end_idxs` - the `window` size property of the
@@ -351,7 +351,7 @@ class FeatureCollection:
                  is also None). (Note that the `stride` argument of this method takes
                  precedence over the `stride` property of the `FeatureDescriptor`s).
             By default None.
-        segment_end_idxs: pd.Index, optional
+        segment_end_idxs: Union[list, np.ndarray, pd.Series, pd.Index], optional
             The end indices for the segmented windows. If None, the end indices will be
             computed from the data using either
             - the `segment_start_idxs` + the `window` size property of the

--- a/tsflex/features/feature_collection.py
+++ b/tsflex/features/feature_collection.py
@@ -266,7 +266,6 @@ class FeatureCollection:
         def get_stroll_function(idx):
             key_idx = np.searchsorted(lengths, idx, "right")  # right bc idx starts at 0
             key, win = keys_wins_strides[key_idx]
-            print(key, win)
 
             feature = self._feature_desc_dict[keys_wins_strides[key_idx]][
                 idx - lengths[key_idx]

--- a/tsflex/features/feature_collection.py
+++ b/tsflex/features/feature_collection.py
@@ -114,9 +114,8 @@ class FeatureCollection:
 
         """
         return sum(
-            len(fd.function.output_names)
-            for fds in self._feature_desc_dict.values()
-            for fd in fds
+            fd.get_nb_output_features() 
+            for fd in flatten(self._feature_desc_dict.values())
         )
 
     @staticmethod
@@ -241,8 +240,8 @@ class FeatureCollection:
         stroll, function = get_stroll_func(idx)
         return stroll.apply_func(function)
 
-    def _get_stroll(self, kwargs):
-        return StridedRollingFactory.get_segmenter(**kwargs)
+    # def _get_stroll(self, kwargs):
+        # return StridedRollingFactory.get_segmenter(**kwargs)
 
     def _stroll_feat_generator(
         self,
@@ -267,6 +266,7 @@ class FeatureCollection:
         def get_stroll_function(idx):
             key_idx = np.searchsorted(lengths, idx, "right")  # right bc idx starts at 0
             key, win = keys_wins_strides[key_idx]
+            print(key, win)
 
             feature = self._feature_desc_dict[keys_wins_strides[key_idx]][
                 idx - lengths[key_idx]
@@ -287,8 +287,8 @@ class FeatureCollection:
                 approve_sparsity=approve_sparsity,
                 func_data_type=function.input_type,
             )
-            # stroll = StridedRollingFactory.get_segmenter(**stroll_arg_dict)
-            stroll = self._get_stroll(stroll_arg_dict)
+            stroll = StridedRollingFactory.get_segmenter(**stroll_arg_dict)
+            # stroll = self._get_stroll(stroll_arg_dict)
             return stroll, function
 
         return get_stroll_function
@@ -492,7 +492,7 @@ class FeatureCollection:
             assert all(
                 fd.window is not None
                 for fd in flatten(self._feature_desc_dict.values())
-            ), "Each feature descriptor must have a window when not both ,,"
+            ), "Each feature descriptor must have a window when not both segment_start_idxs and segment_end_idxs are provided"
         if segment_start_idxs is not None and segment_end_idxs is not None:
             assert len(segment_start_idxs) == len(
                 segment_end_idxs
@@ -555,8 +555,6 @@ class FeatureCollection:
             ]  # TODO: check memory efficiency of ths
             for n, s, in series_dict.items()
         }
-
-        print(start, end)
 
         # TODO: segment indices trimmen?
 

--- a/tsflex/features/segmenter/strided_rolling.py
+++ b/tsflex/features/segmenter/strided_rolling.py
@@ -151,9 +151,10 @@ class StridedRolling(ABC):
                 "Values in segment_start_idxs should be <= correspend segment_end_idxs value"
             )
 
-        assert AttributeParser.check_expected_type(
-            [window] + ([] if strides is None else strides), self.win_str_type
-        )
+        if window is not None:
+            assert AttributeParser.check_expected_type(
+                [window] + ([] if strides is None else strides), self.win_str_type
+            )
 
         self.window = window
         self.strides = strides

--- a/tsflex/features/segmenter/strided_rolling.py
+++ b/tsflex/features/segmenter/strided_rolling.py
@@ -681,13 +681,8 @@ def _sliding_strided_window_1d(
     """
     # window and step in samples
     assert data.ndim == 1, "data must be 1 dimensional"
-
-    if isinstance(window, float):
-        assert window.is_integer(), "window must be an int!"
-        window = int(window)
-    if isinstance(step, float):
-        assert step.is_integer(), "step must be an int!"
-        step = int(step)
+    assert isinstance(window, (int, np.integer)), "window must be an integer"
+    assert isinstance(step, (int, np.integer)), "step must be an integer"
 
     assert (step >= 1) & (window < len(data))
 

--- a/tsflex/features/segmenter/strided_rolling.py
+++ b/tsflex/features/segmenter/strided_rolling.py
@@ -480,13 +480,12 @@ class StridedRolling(ABC):
                 ]
 
         elapsed = time.time() - t_start
-        log_strides = (
-            tuple() if self.strides is None else tuple(str(s) for s in self.strides)
-        )
+        log_strides = "manual" if self.strides is None else tuple(map(str, self.strides))
+        log_window = "manual" if self.window is None else self.window
         logger.info(
             f"Finished function [{func.func.__name__}] on "
             f"{[self.series_key]} with window-stride "
-            f"[{self.window}, {log_strides}] in [{elapsed} seconds]!"
+            f"[{log_window}, {log_strides}] in [{elapsed} seconds]!"
         )
 
         return pd.DataFrame(index=self.index, data=feat_out)

--- a/tsflex/features/segmenter/strided_rolling_factory.py
+++ b/tsflex/features/segmenter/strided_rolling_factory.py
@@ -63,13 +63,13 @@ class StridedRollingFactory:
             The constructed StridedRolling instance.
 
         """
-        data_dtype = AttributeParser.determine_type(data)
+        data_dtype = AttributeParser.determine_type(data)  
         if strides is None:
             args_dtype = AttributeParser.determine_type(window)
         else:
             args_dtype = AttributeParser.determine_type([window] + strides)
 
-        if data_dtype.value == args_dtype.value:
+        if window is None or data_dtype.value == args_dtype.value:
             return StridedRollingFactory._datatype_to_stroll[data_dtype](
                 data, window, strides, **kwargs
             )


### PR DESCRIPTION
Add support for `segment_start_idxs` and/or `segment_end_idxs` in the `FeatureCollection.calculate` method (previously we called this internally the setpoints)
- [x] add arguments to `calculate` and test it
- [x] make window optional in in `FeatureDescriptor` (and `MultipleFeatureDescriptors`) and test it
- [x] update logging and test it
- [x] update `reduce` method and test it
- [x] cleanup some code in `_sliding_strided_window_1d` 