### PR TITLE
time-series batch / whole-series feature calculation

### DIFF
--- a/tests/test_features_feature_collection.py
+++ b/tests/test_features_feature_collection.py
@@ -2141,3 +2141,155 @@ def test_feature_collection_various_timezones_segment_start_idxs():
     )
     res = fc.calculate(s_usa, segment_start_idxs=s_none.index[:3].values, n_jobs=0, return_df=True)
     assert np.all(res.values == [])
+
+
+
+# --------------------------- global_segmentation ---------------------------
+
+
+
+# --------------------------- Start & end indices ---------------------------
+def test_int_segment_idxs_time_indexed_data():
+    # Create some time-indexed data
+    series = np.random.rand(100)
+    ts_index = pd.date_range(start="2022-06-09 00:00:00", periods=len(series), freq="min")
+    df = pd.DataFrame({"Value": series}, index=ts_index)
+
+    # NOTE the window is of int dtype -> `TimeIndexSampleTridedRolling`
+    fc_tis_stroll = FeatureCollection(
+        FeatureDescriptor(
+            function = np.mean,
+            series_name="Value",
+            window=len(df)+20,
+            stride=100
+        )
+    )
+
+    # NOTE: The window and sride are of time dtype -> TimeStridedRolling
+    fc_t_stroll = FeatureCollection(
+        FeatureDescriptor(
+            function = np.mean,
+            series_name="Value",
+            window="100min",
+            stride="1min"
+        )
+    )
+
+    # Integer alike segment indices are not supported for time-indexed data
+    # -> `TimeIndexSampleTridedRolling` is used (based on win-stride-data dtype)
+    with pytest.raises((NotImplementedError, RuntimeError)):
+        fc_tis_stroll.calculate(data=df, segment_start_idxs=[0, 50, 100], n_jobs=0, return_df=True)
+
+    # Integer alike segment indices are not supported for time-indxed data
+    # -> `TimeStridedRolling` is used (based on win-stride-data dtype)
+    with pytest.raises((NotImplementedError, RuntimeError)):
+        fc_t_stroll.calculate(data=df, segment_start_idxs=[0, 50, 100], n_jobs=0, return_df=True)
+
+def test_time_segment_idxs_time_indexed_data():
+    # Create some time-indexed data
+    series = np.random.rand(100)
+    ts_index = pd.date_range(start="2022-06-09 00:00:00", periods=len(series), freq="min")
+    df = pd.DataFrame({"Value": series}, index=ts_index)
+
+    # NOTE the window is of int dtype -> `TimeIndexSampleTridedRolling`
+    fc_tis_stroll = FeatureCollection(
+        FeatureDescriptor(
+            function = np.mean,
+            series_name="Value",
+            window=len(df)+20,
+            stride=100
+        )
+    )
+    # NOTE: The window and sride are of time dtype -> TimeStridedRolling
+    fc_t_stroll = FeatureCollection(
+        FeatureDescriptor(
+            function = np.mean,
+            series_name="Value",
+            window="100min",
+            stride="1min"
+        )
+    )
+
+    # Time based segment indices are supported for time-indexed data
+    # NOTE: it does not matter whether the window and stride are of int or time dtype
+    #   within the FeatureDescriptors When both the segment_start_idxs and 
+    #   segment_end_idxs are set
+    fc_tis_stroll.calculate(
+        data=df, 
+        segment_start_idxs=[df.index[0]], 
+        segment_end_idxs=[df.index[-1]], 
+        n_jobs=0, 
+        return_df=True
+    )
+
+    # And this must most certainly work for a FeatureCollection withholding time-based
+    # window-stride featureDescriptors
+    fc_t_stroll.calculate(
+        data=df, 
+        segment_start_idxs=[df.index[0]], 
+        segment_end_idxs=[df.index[-1]], 
+        n_jobs=0, 
+        return_df=True
+      )
+
+# --------------------------- calculate unsegmented ---------------------------
+def test_calculate_unsegmented_time_index_data():
+    series = np.random.rand(100)
+    ts_index = pd.date_range(start="2022-06-09 00:00:00", periods=len(series), freq="min")
+    df = pd.DataFrame({"Value": series}, index=ts_index)
+
+    fc_no_ws_args = FeatureCollection(
+        FeatureDescriptor(
+            function = len, #np.mean,
+            series_name="Value",
+        )
+    )
+    fc_ws_int = FeatureCollection(
+        FeatureDescriptor(
+            function = len, #np.mean,
+            series_name="Value",
+            window=10,
+            stride=10
+        )
+    )
+    fc_ws_float = FeatureCollection(
+        FeatureDescriptor(
+            function = len, #np.mean,
+            series_name="Value",
+            window=5.6,
+            stride=6.6
+        )
+    )
+    fc_ws_time = FeatureCollection(
+        FeatureDescriptor(
+            function = len, #np.mean,
+            series_name="Value",
+            window="5min",
+            stride="1hour"
+        )
+    )
+
+    for fc in [fc_ws_int, fc_no_ws_args, fc_ws_time]:
+        out = fc.calculate_unsegmented(data=df, window_idx='end', return_df=True, include_final_window=True, n_jobs=0)
+        # assert that all the data was used
+        assert out.values[0] == len(df)
+        assert out.index[-1] > df.index[-1]
+
+
+def test_calculate_unsegmented_time_index_data():
+    series = np.random.rand(100)
+    ts_index = pd.date_range(start="2022-06-09 00:00:00", periods=len(series), freq="min")
+    df = pd.DataFrame({"Value": series}, index=ts_index)
+
+    fc = FeatureCollection(
+        FeatureDescriptor(
+            function = len, #np.mean,
+            series_name="Value",
+            window=len(df)+20,
+            # stride=100
+        )
+    )
+    out = fc.calculate_unsegmented(data=df, window_idx='end', return_df=True, include_final_window=True, n_jobs=0)
+    # assert that all the data was used
+    assert out.values[0] == len(df)
+    assert out.index[-1] > df.index[-1]

--- a/tests/test_features_feature_collection.py
+++ b/tests/test_features_feature_collection.py
@@ -2269,27 +2269,72 @@ def test_calculate_unsegmented_time_index_data():
         )
     )
 
-    for fc in [fc_ws_int, fc_no_ws_args, fc_ws_time]:
+    # NOTE: the datatype of the FeatureDescriptors does not matter
+    # at all when the calclulate unsegmented method is used 
+    for fc in [fc_ws_int, fc_no_ws_args, fc_ws_time, fc_ws_float]:
         out = fc.calculate_unsegmented(data=df, window_idx='end', return_df=True, include_final_window=True, n_jobs=0)
         # assert that all the data was used
         assert out.values[0] == len(df)
+        # assert that the otuput index is greater than the data index
+        # NOTE: this means that a datapoint is used, which is just outside the
+        # datarange of out
         assert out.index[-1] > df.index[-1]
 
+        out = fc.calculate_unsegmented(data=df, window_idx='begin', return_df=True, include_final_window=True, n_jobs=0)
+        # assert that all the data was used
+        assert out.values[0] == len(df)
+        # Assert that the output index ins the first index item of data
+        assert out.index[0] == df.index[0]
 
-def test_calculate_unsegmented_time_index_data():
+
+def test_calculate_unsegmented_numeric_index_data():
     series = np.random.rand(100)
-    ts_index = pd.date_range(start="2022-06-09 00:00:00", periods=len(series), freq="min")
-    df = pd.DataFrame({"Value": series}, index=ts_index)
+    df = pd.DataFrame({"Value": series})
 
-    fc = FeatureCollection(
+    fc_no_ws_args = FeatureCollection(
         FeatureDescriptor(
             function = len, #np.mean,
             series_name="Value",
-            window=len(df)+20,
-            # stride=100
         )
     )
-    out = fc.calculate_unsegmented(data=df, window_idx='end', return_df=True, include_final_window=True, n_jobs=0)
-    # assert that all the data was used
-    assert out.values[0] == len(df)
-    assert out.index[-1] > df.index[-1]
+    fc_ws_int = FeatureCollection(
+        FeatureDescriptor(
+            function = len, #np.mean,
+            series_name="Value",
+            window=10,
+            stride=10
+        )
+    )
+    fc_ws_float = FeatureCollection(
+        FeatureDescriptor(
+            function = len, #np.mean,
+            series_name="Value",
+            window=5.6,
+            stride=6.6
+        )
+    )
+    fc_ws_time = FeatureCollection(
+        FeatureDescriptor(
+            function = len, #np.mean,
+            series_name="Value",
+            window="5min",
+            stride="1hour"
+        )
+    )
+
+    # NOTE: the datatype of the FeatureDescriptors does not matter
+    # at all when the calclulate unsegmented method is used 
+    for fc in [fc_ws_int, fc_no_ws_args, fc_ws_time, fc_ws_float]:
+        out = fc.calculate_unsegmented(data=df, window_idx='end', return_df=True, include_final_window=True, n_jobs=0)
+        # assert that all the data was used
+        assert out.values[0] == len(df)
+        # assert that the otuput index is greater than the data index
+        # NOTE: this means that a datapoint is used, which is just outside the
+        # datarange of out
+        assert out.index[-1] > df.index[-1]
+
+        out = fc.calculate_unsegmented(data=df, window_idx='begin', return_df=True, include_final_window=True, n_jobs=0)
+        # assert that all the data was used
+        assert out.values[0] == len(df)
+        # Assert that the output index ins the first index item of data
+        assert out.index[0] == df.index[0]

--- a/tsflex/utils/attribute_parsing.py
+++ b/tsflex/utils/attribute_parsing.py
@@ -7,6 +7,7 @@ from enum import IntEnum
 from typing import Any
 
 import pandas as pd
+import numpy as np
 
 from tsflex.utils.time import parse_time_arg
 
@@ -31,16 +32,26 @@ class AttributeParser:
         if data is None:
             return DataType.UNDEFINED
 
-        elif isinstance(data, (pd.Series, pd.DataFrame)):
-            dtype_str = str(data.index.dtype)
+        elif isinstance(data, (pd.Series, pd.DataFrame, np.ndarray)):
+            if isinstance(data, np.ndarray):
+                if not len(data):
+                    return DataType.UNDEFINED
+                dtype_str = str(data.dtype)
+            else:
+                dtype_str = str(data.index.dtype)
             if AttributeParser._datetime_regex.match(dtype_str) is not None:
                 return DataType.TIME
+            elif dtype_str == 'object':
+                # we make the assumption that the fist element is the same type as the 
+                # rest
+                return AttributeParser.determine_type(data[0])
             elif any(r.match(dtype_str) for r in AttributeParser._numeric_regexes):
                 return DataType.SEQUENCE
 
         elif isinstance(data, (int, float)):
             return DataType.SEQUENCE
-
+        elif isinstance(data, pd.Timestamp):
+            return DataType.TIME
         elif isinstance(data, (str, pd.Timedelta)):
             # parse_time_arg already raises an error when an invalid datatype is passed
             parse_time_arg(data)
@@ -54,7 +65,7 @@ class AttributeParser:
                 )
             return dtype_list[0]
 
-        raise ValueError(f"Unsupported data type {type(data)}")
+        raise ValueError(f"Unsupported data type {type(data)} {str(data.dtype)} {data[:10]}")
 
     @staticmethod
     def check_expected_type(data: Any, expected: DataType) -> bool:

--- a/tsflex/utils/attribute_parsing.py
+++ b/tsflex/utils/attribute_parsing.py
@@ -65,7 +65,7 @@ class AttributeParser:
                 )
             return dtype_list[0]
 
-        raise ValueError(f"Unsupported data type {type(data)} {str(data.dtype)} {data[:10]}")
+        raise ValueError(f"Unsupported data type {type(data)}")
 
     @staticmethod
     def check_expected_type(data: Any, expected: DataType) -> bool:


### PR DESCRIPTION
### Objectives:
#### Functionality
- [ ] *convenient* way to extract features over the whole, unsegmented data (see also #67)
   - [ ] Discuss + decide together with @jvdd @mbignotti what option seems best to serve this functionality (regarding end user perspective)
   
Available options:
1. introduce a new method to the FeatureCollection (as done here):
   * **advantages** ✅ 
      * Explicit method definition, less confusion for end-users
   * **disadvanges** :x:
      * A new method is introduced / less uniform interface to perform computation
2. Perform unsegmented feature computation when **all** window and/or stride are NOT set. 
   * **advantages** ✅ 
      * more homogenous interface
   * **disadvanges** :x:
     * somewhat more implicitness
  code example:
```python
 # NOTE: window and stride parameters are omitted. 
fc = FeatureCollection(
    FeatureDescriptor(
        function = np.mean,
        series_name="Value",
    )
)

# Uses the whole (unsegmented) series of `data` to 
# calculate the features. method remains the same.
fc.calculate(data=df, return_df=True)
```

3. Perform unsegmented feature computation when **all** windows are set to `-1` 
4. a combination of (2.) and (3.)

As for now, this is performed by introducing the `calculate_unsegmented` method to the FeatureCollection:

#### Bug fixes
- [ ] fix the `window_idx="end"` and (window-size > data-range) bug

